### PR TITLE
Minor changes to core.py and file writing to help with looking at TWC

### DIFF
--- a/ppodd/core.py
+++ b/ppodd/core.py
@@ -104,6 +104,7 @@ class decades_dataset(OrderedDict):
         and a dictionary of processing modules
     """
     def __init__(self,*args,**kwargs):
+        OrderedDict.__init__(self)
         self.history=''
         self.modules=OrderedDict()
         self.outparas=None
@@ -114,7 +115,6 @@ class decades_dataset(OrderedDict):
         self.getmods()
         from ppodd.pod.write_nc import write_nc
         self.write_nc=write_nc(self)
-        OrderedDict.__init__(self)
         self.add_para('Attribute','Conventions','CF-1.4')
         #:Conventions = "NCAR-RAF/nimbus"
         #:ConventionsURL = "http://www.eol.ucar.edu/raf/Software/netCDF.html" ;

--- a/ppodd/pod/write_nc.py
+++ b/ppodd/pod/write_nc.py
@@ -203,7 +203,10 @@ Saving as output.nc""")
                 else:
                     data=par.data
                 # Replace all nans in data array
-                data[~np.isfinite(data)]=fill_value
+                try:
+                    data[~np.isfinite(data)]=fill_value
+                except TypeError:
+                    pass
                 try:
                     z=np.float_(data).asmasked(start=start,end=end,fill_value=fill_value)
                     para[:]=z[:]


### PR DESCRIPTION
I don't know if you still use this processing code.  There were a couple of issues when we tried to look at raw TWC data.  Writing anything but float/real data to NetCDF was impossible because of a check for isfinite.  There seemed to be a problem with the initialisation of the OrderedDict that is the decades_dataset.